### PR TITLE
Restrict split to max 4 to prevent crash

### DIFF
--- a/registrypol/values.py
+++ b/registrypol/values.py
@@ -81,8 +81,8 @@ class RegistryValue():
             raise TypeError(f'invalid type for data')
 
     @classmethod
-    def from_bytes(cls, bytes):
-        key, value, type, size, data = bytes[2:-2].split(b'\x3b\x00')
+    def from_bytes(cls, input_bytes):
+        key, value, type, size, data = bytes(input_bytes[2:-2]).split(b'\x3b\x00', 4)
 
         return cls(
             key=key.decode('utf-16-le'),


### PR DESCRIPTION
When a registry entry contains the `;` symbol, the parser which splits on `b"\x3b\x00` (`;`) will crash due to too many values:
![image](https://github.com/user-attachments/assets/75f63030-e1d6-4969-93a5-9b705eaf7884)

This PR limits the split to exactly 4 splits, so that the data which potentially could contain this character remains intact.

Would highly appreciate if you could also push the fix to pypi, so that i can use it in my project: https://github.com/NeffIsBack/wsuks

Thanks for your work! :v: