### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,9 @@
 
 name: Build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/liamsennitt/registrypol/security/code-scanning/1](https://github.com/liamsennitt/registrypol/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the minimum permissions required for the workflow to function correctly. Since the workflow only reads repository contents and does not perform any write operations, the permissions can be set to `contents: read`. This change should be applied at the root level of the workflow to cover all jobs unless specific jobs require different permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
