### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,7 @@
 # For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
 
 name: Publish
+
 permissions:
   contents: read
   packages: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,9 @@
 # For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
 
 name: Publish
+permissions:
+  contents: read
+  packages: write
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/liamsennitt/registrypol/security/code-scanning/2](https://github.com/liamsennitt/registrypol/security/code-scanning/2)

To fix the issue, add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function. Since the workflow involves checking out the repository and publishing a package, it likely requires `contents: read` for accessing the repository and `packages: write` for publishing the package. These permissions should be explicitly specified.

The `permissions` block should be added immediately after the `name` field (line 4) to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
